### PR TITLE
bump mercury version

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-mercury/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/game.libretro.bsnes-mercury/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="game.libretro.bsnes-mercury"
-PKG_VERSION="8c6494c"
+PKG_VERSION="a06819c"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
This bumps for a typo fix in the game addon.
As a result the .so wasn't placed in /usr/lib/kodi/addons.
Don't know if a PR is right in this case as you have to call mkpkg-game.libretro.bsnes-mercury anyway, though :)
